### PR TITLE
Add SSL starter script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ BankSim is a small banking website for **Wien ONline-Bank** built with [Flask](h
    ```
    This starts a development server on `http://127.0.0.1:80/`.
 
+5. **Run with SSL** (requires `cert.pem` and `key.pem` in the project directory):
+   ```bash
+   python run_ssl.py
+   ```
+   The server will listen on `https://127.0.0.1:443/`.
+
 On first run, a SQLite database (`database.db`) will be created automatically. You can then register a user and log in to access the pages.
 
 ## Windows Setup

--- a/run_ssl.py
+++ b/run_ssl.py
@@ -1,0 +1,7 @@
+"""Startet die Flask-App mit SSL-Unterstützung."""
+
+from app import app
+
+
+if __name__ == "__main__":
+    app.run(debug=True, port=443, ssl_context=("cert.pem", "key.pem"))


### PR DESCRIPTION
## Summary
- add a small script `run_ssl.py` to start the Flask app with SSL
- document how to run the server with SSL in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684aded8f8d0832686ece6fb88bae8e7