### PR TITLE
Store IBAN/BIC and show details

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,6 +23,9 @@ class Transaction(db.Model):
     date = db.Column(db.Date, nullable=False)
     description = db.Column(db.String(200), nullable=False)
     amount = db.Column(db.Float, nullable=False)
+    iban = db.Column(db.String(34))
+    bic = db.Column(db.String(11))
+    purpose = db.Column(db.String(200))
     user = db.relationship('User', backref=db.backref('transactions', lazy=True))
 
 with app.app_context():
@@ -104,6 +107,9 @@ def transfer():
         date=date.today(),
         description=description,
         amount=-abs(amount),
+        iban=iban,
+        bic=bic,
+        purpose=purpose,
     )
     db.session.add(txn)
     db.session.commit()
@@ -134,6 +140,8 @@ def sepa_transfer():
         date=date.today(),
         description=description,
         amount=-abs(amount),
+        iban=iban,
+        purpose=purpose,
     )
     db.session.add(txn)
     db.session.commit()

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
             border-color: var(--red);
             box-shadow: 0 0 0 0.25rem rgba(157, 0, 0, 0.25);
         }
+        .tx-row { cursor: pointer; }
     </style>
 </head>
 <body class="bg-light">
@@ -121,7 +122,18 @@
                             </thead>
                             <tbody>
                             {% for t in transactions %}
-                                <tr><td>{{ t.date.strftime('%d.%m.%Y') }}</td><td>{{ t.description }}</td><td>{{ '%+.2f' % t.amount }} €</td></tr>
+                                <tr class="tx-row" onclick="toggleDetails(this)"><td>{{ t.date.strftime('%d.%m.%Y') }}</td><td>{{ t.description }}</td><td>{{ '%+.2f' % t.amount }} €</td></tr>
+                                {% if t.iban or t.bic or t.purpose %}
+                                <tr class="tx-details d-none">
+                                    <td colspan="3">
+                                        <ul class="list-unstyled mb-0">
+                                            {% if t.iban %}<li><strong>IBAN:</strong> {{ t.iban }}</li>{% endif %}
+                                            {% if t.bic %}<li><strong>BIC:</strong> {{ t.bic }}</li>{% endif %}
+                                            {% if t.purpose %}<li><strong>Verwendungszweck:</strong> {{ t.purpose }}</li>{% endif %}
+                                        </ul>
+                                    </td>
+                                </tr>
+                                {% endif %}
                             {% endfor %}
 
                             </tbody>
@@ -328,6 +340,13 @@
                 </table>
                 <button class="btn btn-primary" onclick="showPage('balance')">Zur Übersicht</button>
             `;
+        }
+
+        function toggleDetails(row) {
+            const next = row.nextElementSibling;
+            if (next && next.classList.contains('tx-details')) {
+                next.classList.toggle('d-none');
+            }
         }
 
         function submitReport(event) {


### PR DESCRIPTION
## Summary
- extend `Transaction` model with `iban`, `bic` and `purpose`
- persist those fields when creating transfers
- allow users to toggle extra information on the Umsatzseite

## Testing
- `python -m py_compile app.py manage_db.py create_user_with_history.py`

------
https://chatgpt.com/codex/tasks/task_e_684baf9386988326859eac3974f8fb3e