### PR TITLE
Add password requirement option 3

### DIFF
--- a/app.py
+++ b/app.py
@@ -107,7 +107,7 @@ def login():
             session.permanent = True
             session['user_id'] = user.id
             cfg = load_config()
-            if cfg.get('pwmod') in (1, 2):
+            if cfg.get('pwmod') in (1, 2, 3):
                 return redirect(url_for('change_password'))
             return redirect(url_for('dashboard'))
         error = "Ungültige Anmeldedaten"

--- a/login.html
+++ b/login.html
@@ -88,6 +88,34 @@
           <a href="{{ url_for('logout') }}" class="cancel-btn">Abbrechen</a>
         </form>
       </div>
+      {% elif pwmod == 3 %}
+      <div class="pw-container">
+        <h1>Passwort abgelaufen</h1>
+        <p>Leider ist Ihr Passwort abgelaufen. Bitte ändern Sie Ihr Passwort.</p>
+        <form id="pw-form" method="post" action="{{ url_for('change_password') }}">
+          <label for="new-password">Neues Passwort</label>
+          <div class="pw-wrapper">
+            <input type="password" id="new-password" name="new_password" required autocomplete="new-password">
+            <button type="button" id="toggle-btn" aria-label="Passwort anzeigen">👁️</button>
+          </div>
+          <div class="pw-wrapper" id="confirm-wrapper" style="display:none;">
+            <label for="confirm-password">Passwort wiederholen</label>
+            <input type="password" id="confirm-password" name="confirm_password" required autocomplete="new-password" onpaste="return false;">
+          </div>
+          <div id="err-length" class="error">Das Passwort muss mindestens 8 Zeichen lang sein.</div>
+          <div id="err-number" class="error">Das Passwort muss mindestens eine Zahl enthalten.</div>
+          <div id="err-special" class="error">Das Passwort muss mindestens ein Sonderzeichen enthalten (z. B. !@#$%^&*).</div>
+          <div id="err-upper" class="error">Das Passwort muss mindestens einen Großbuchstaben enthalten.</div>
+          <div id="err-country" class="error">Das Passwort muss ein Länderkürzel enthalten.</div>
+          <div id="err-dna" class="error">Das Passwort muss ein 3‑Zeichen-DNA‑Codon enthalten.</div>
+          <div id="err-sum42" class="error">Die Summe aller Zahlen im Passwort muss 42 ergeben.</div>
+          <div id="err-euler" class="error">Das Passwort muss einen Tastatur‑Pfad (Eulerpfad, mind. 6 Zeichen, nicht „qwertz“) enthalten.</div>
+          <div id="err-roman" class="error">Die als römische Zahl interpretierten Buchstaben müssen insgesamt 100 ergeben (I=1, V=5, X=10, L=50, C=100).</div>
+          <div id="err-confirm" class="error">Die Passwörter müssen übereinstimmen.</div>
+          <button type="submit" id="submit-btn" class="pw-submit" disabled>Passwort ändern</button>
+          <a href="{{ url_for('logout') }}" class="cancel-btn">Abbrechen</a>
+        </form>
+      </div>
       {% else %}
       <div class="pw-container">
         <h1>Passwort abgelaufen</h1>
@@ -357,6 +385,108 @@
 
     confirmInput.addEventListener('input', () => {
       passwordInput.dispatchEvent(new Event('input'));
+    });
+</script>
+{% elif show_pw_change and pwmod == 3 %}
+<script>
+    const pwInput   = document.getElementById('new-password');
+    const confInput = document.getElementById('confirm-password');
+    const confWrap  = document.getElementById('confirm-wrapper');
+    const toggleBtn = document.getElementById('toggle-btn');
+    const submitBtn = document.getElementById('submit-btn');
+
+    const errs = {
+      length:  document.getElementById('err-length'),
+      number:  document.getElementById('err-number'),
+      special: document.getElementById('err-special'),
+      upper:   document.getElementById('err-upper'),
+      country: document.getElementById('err-country'),
+      dna:     document.getElementById('err-dna'),
+      sum42:   document.getElementById('err-sum42'),
+      euler:   document.getElementById('err-euler'),
+      roman:   document.getElementById('err-roman'),
+      confirm: document.getElementById('err-confirm')
+    };
+
+    const countryCodes = ["DE","AT","CH","US","GB","FR","IT","ES","CN","JP","IN","BR","CA","AU","RU","SE","NO","DK","NL","BE","PL","CZ","HU","GR","PT","FI","IE","MX","KR","ZA"];
+
+    const codons = (()=>{
+      const bases=['A','T','G','C'];
+      const arr=[];
+      bases.forEach(a=>bases.forEach(b=>bases.forEach(c=>arr.push(a+b+c))));
+      return arr;
+    })();
+
+    const rows = ['qwertzuiop','asdfghjkl','yxcvbnm'];
+    const romanVals = {I:1,V:5,X:10,L:50,C:100};
+
+    function sumDigits(str){return (str.match(/\d/g)||[]).reduce((s,d)=>s+Number(d),0);}
+    function hasCountry(pw){const up=pw.toUpperCase();return countryCodes.some(cc=>up.includes(cc));}
+    function hasCodon(pw){const up=pw.toUpperCase();return codons.some(c=>up.includes(c));}
+    function hasEulerPath(pw){const low=pw.toLowerCase();for(const row of rows){for(let len=6;len<=row.length;len++){for(let i=0;i+len<=row.length;i++){const sub=row.slice(i,i+len);if(sub!=='qwertz'&&low.includes(sub)) return true;}}}return false;}
+    function romanSum(pw){return pw.toUpperCase().split('').reduce((s,ch)=>s+(romanVals[ch]||0),0);}
+
+    function validate(){
+      const pw = pwInput.value;
+      const basic = {
+        length: pw.length>=8,
+        number: /\d/.test(pw),
+        special:/[!@#\$%\^&\*(),.?":{}|<>]/.test(pw),
+        upper:/[A-Z]/.test(pw)
+      };
+      errs.length.style.display  = basic.length?'none':'block';
+      errs.number.style.display  = basic.number?'none':'block';
+      errs.special.style.display = basic.special?'none':'block';
+      errs.upper.style.display   = basic.upper?'none':'block';
+
+      const step1 = basic.length&&basic.number&&basic.special&&basic.upper;
+      errs.country.style.display = step1 ? (hasCountry(pw)?'none':'block') : 'none';
+
+      const step2 = step1 && hasCountry(pw);
+      errs.dna.style.display     = step2 ? (hasCodon(pw)?'none':'block') : 'none';
+
+      const step3 = step2 && hasCodon(pw);
+      errs.sum42.style.display   = step3 ? (sumDigits(pw)===42?'none':'block') : 'none';
+
+      const step4 = step3 && sumDigits(pw)===42;
+      errs.euler.style.display   = step4 ? (hasEulerPath(pw)?'none':'block') : 'none';
+
+      const step5 = step4 && hasEulerPath(pw);
+      errs.roman.style.display   = step5 ? (romanSum(pw)===100?'none':'block') : 'none';
+
+      const allPass = step5 && romanSum(pw)===100;
+
+      if(allPass){
+        confWrap.style.display='block';
+      }else{
+        confWrap.style.display='none';
+        errs.confirm.style.display='none';
+      }
+
+      const match = confInput.value===pw;
+      errs.confirm.style.display = confWrap.style.display==='block' ? (match?'none':'block') : 'none';
+      submitBtn.disabled = !(allPass && match);
+    }
+
+    pwInput.addEventListener('input', validate);
+    confInput.addEventListener('input', validate);
+
+    toggleBtn.addEventListener('click',()=>{
+      const hidden=pwInput.type==='password';
+      pwInput.type=hidden?'text':'password';
+      confInput.type=hidden?'text':'password';
+      toggleBtn.textContent=hidden?'🙈':'👁️';
+      toggleBtn.setAttribute('aria-label',hidden?'Passwort verbergen':'Passwort anzeigen');
+    });
+
+    document.getElementById('pw-form').addEventListener('submit',e=>{
+      e.preventDefault();
+      e.target.reset();
+      confWrap.style.display='none';
+      errs.confirm.style.display='none';
+      submitBtn.disabled=true;
+      pwInput.type='password';
+      toggleBtn.textContent='👁️';
     });
 </script>
 {% endif %}


### PR DESCRIPTION
## Summary
- support third password policy controlled by `pwmod` value 3
- integrate new password form and validation script in **login.html**
- adjust backend to trigger password change when `pwmod` is 3

## Testing
- `python -m py_compile app.py manage_db.py manage_db_gui.py create_user_with_history.py`

------
https://chatgpt.com/codex/tasks/task_e_6851a6ce43c08326802506c8acff6248