### PR TITLE
Fix pwmod 3 password change

### DIFF
--- a/login.html
+++ b/login.html
@@ -479,15 +479,7 @@
       toggleBtn.setAttribute('aria-label',hidden?'Passwort verbergen':'Passwort anzeigen');
     });
 
-    document.getElementById('pw-form').addEventListener('submit',e=>{
-      e.preventDefault();
-      e.target.reset();
-      confWrap.style.display='none';
-      errs.confirm.style.display='none';
-      submitBtn.disabled=true;
-      pwInput.type='password';
-      toggleBtn.textContent='👁️';
-    });
+    // Submit the form normally so the server can update the password
 </script>
 {% endif %}
 </body>

--- a/vorlage-passwortaendern-option3.html
+++ b/vorlage-passwortaendern-option3.html
@@ -165,16 +165,7 @@
       toggleBtn.setAttribute('aria-label',hidden?'Passwort verbergen':'Passwort anzeigen');
     });
 
-    document.getElementById('pw-form').addEventListener('submit',e=>{
-      e.preventDefault();
-      alert('Ihr Passwort wurde erfolgreich geändert.');
-      e.target.reset();
-      confWrap.style.display='none';
-      errs.confirm.style.display='none';
-      submitBtn.disabled=true;
-      pwInput.type='password';
-      toggleBtn.textContent='👁️';
-    });
+    // Submit the form normally so the server can update the password
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow password change form to submit normally when `pwmod` is 3
- replicate the fix in the optional template

## Testing
- `python -m py_compile app.py`
- `flake8 || true`

------
https://chatgpt.com/codex/tasks/task_e_685284c2be4c83268581dd4684e1a94c